### PR TITLE
Fixed an error where project path with a space character will cause b…

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "make project",
             "type": "shell",
-            "command": "cd ${workspaceFolder}/build && rm -rf ${workspaceFolder}/.vscode/ipch && cmake .. && make",
+            "command": "cd '${workspaceFolder}/build' && rm -rf '${workspaceFolder}/.vscode/ipch' && cmake .. && make",
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
A fix for [this issue.](https://piazza.com/class/kjk50uisbw938n?cid=16_f5)  
Build task will fail if the path to project directory contains a space char.  
Fixed .vscode/tasks.json  